### PR TITLE
Expose the gRPC port and fix rendering of CIDR block list for loadBalancerSourceRanges

### DIFF
--- a/charts/uptrace/templates/service.yaml
+++ b/charts/uptrace/templates/service.yaml
@@ -17,6 +17,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.service.grpc_port }}
+      targetPort: grpc
+      protocol: TCP
+      name: grpc
   selector:
     app: uptrace
     {{- include "uptrace.selectorLabels" . | nindent 4 }}

--- a/charts/uptrace/templates/service.yaml
+++ b/charts/uptrace/templates/service.yaml
@@ -9,6 +9,7 @@ metadata:
   {{- with .Values.service.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
+
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -20,5 +21,5 @@ spec:
     app: uptrace
     {{- include "uptrace.selectorLabels" . | nindent 4 }}
   {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerSourceRanges)) }}
-  loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges: {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}

--- a/charts/uptrace/templates/uptrace-statefulset.yaml
+++ b/charts/uptrace/templates/uptrace-statefulset.yaml
@@ -43,6 +43,9 @@ spec:
             - name: http
               containerPort: 14318
               protocol: TCP
+            - name: grpc
+              containerPort: 14317
+              protocol: TCP
           livenessProbe:
             httpGet:
               path: /

--- a/charts/uptrace/values.yaml
+++ b/charts/uptrace/values.yaml
@@ -51,7 +51,8 @@ service:
     # service.beta.kubernetes.io/aws-load-balancer-type: "external"
     # service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
   loadBalancerSourceRanges: []
-    # - "0.0.0.0/0"
+    # - "10.0.0.0/8"
+    # - "20.0.0.0/8"
 
 ingress:
   enabled: true

--- a/charts/uptrace/values.yaml
+++ b/charts/uptrace/values.yaml
@@ -47,6 +47,7 @@ securityContext:
 service:
   type: ClusterIP # or LoadBalancer
   port: 80
+  grpc_port: 14317
   annotations: {}
     # service.beta.kubernetes.io/aws-load-balancer-type: "external"
     # service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"


### PR DESCRIPTION
Closes https://github.com/uptrace/helm-charts/issues/6