### PR TITLE
feat(#16): :sparkles: Provide your own environment variables for uptrace container

### DIFF
--- a/charts/uptrace/templates/uptrace-statefulset.yaml
+++ b/charts/uptrace/templates/uptrace-statefulset.yaml
@@ -54,6 +54,8 @@ spec:
             httpGet:
               path: /
               port: http
+          env:
+            {{- toYaml .Values.providedEnv | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/uptrace/templates/uptrace-statefulset.yaml
+++ b/charts/uptrace/templates/uptrace-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
               path: /
               port: http
           env:
-            {{- toYaml .Values.providedEnv | nindent 12 }}
+            {{- toYaml .Values.uptrace.env | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/uptrace/values.yaml
+++ b/charts/uptrace/values.yaml
@@ -108,6 +108,11 @@ tolerations: []
 
 affinity: {}
 
+## Provided env variables for uptrace container
+## You can use those variables in uptrace.config
+## Values are same as here https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+providedEnv: {}
+
 uptrace:
   config:
     ##

--- a/charts/uptrace/values.yaml
+++ b/charts/uptrace/values.yaml
@@ -108,12 +108,12 @@ tolerations: []
 
 affinity: {}
 
-## Provided env variables for uptrace container
-## You can use those variables in uptrace.config
-## Values are same as here https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
-providedEnv: {}
 
 uptrace:
+  ## Provided env variables for uptrace container
+  ## You can use those variables in uptrace.config
+  ## Values are same as here https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+  env: {}
   config:
     ##
     ## Uptrace configuration file.


### PR DESCRIPTION
This PR gives ability to set your own environment variables for uptrace container
structure is compatible with https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/

Closes #16 