### PR TITLE
add an optional volume to clickhouse statefulset  closes #11

### DIFF
--- a/charts/uptrace/templates/clickhouse-statefulset.yaml
+++ b/charts/uptrace/templates/clickhouse-statefulset.yaml
@@ -41,7 +41,13 @@ spec:
           env:
             - name: CLICKHOUSE_DB
               value: uptrace
+          {{- if .Values.clickhouse.persistence.enabled }}
+          volumeMounts:
+          - name: uptrace-clickhouse-data
+            mountPath: /var/lib/clickhouse
+          {{- else }}
           volumeMounts: []
+          {{- end }}
           ports:
             - name: http
               containerPort: 8123
@@ -72,4 +78,17 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes: []
+{{ if .Values.clickhouse.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: uptrace-clickhouse-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      {{- if not (eq .Values.clickhouse.persistence.storageClassName "") }}
+      storageClassName: {{ .Values.clickhouse.persistence.storageClassName }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.clickhouse.persistence.size }}
+{{ end }}
 {{ end }}

--- a/charts/uptrace/values.yaml
+++ b/charts/uptrace/values.yaml
@@ -16,6 +16,10 @@ clickhouse:
     repository: clickhouse/clickhouse-server
     pullPolicy: IfNotPresent
     tag: '22.10'
+  persistence:
+    enabled: true
+    storageClassName: "" # leave empty to use the default storage class
+    size: 8Gi
 
 postgresql:
   enabled: true


### PR DESCRIPTION
Added a volume to the clickhouse instance, making the clickhouse yaml values section look like the following:
```yaml
clickhouse:
  enabled: true
  imagePullSecrets: []
  image:
    repository: clickhouse/clickhouse-server
    pullPolicy: IfNotPresent
    tag: '22.10'
  persistence:
    enabled: true
    storageClassName: "" # leave empty to use the default storage class
    size: 8Gi
```

This was requested in #11 