### PR TITLE
Allow optional persistence for Postgres data

### DIFF
--- a/charts/uptrace/templates/postgresql-statefulset.yaml
+++ b/charts/uptrace/templates/postgresql-statefulset.yaml
@@ -43,7 +43,13 @@ spec:
               value: uptrace
             - name: POSTGRES_PASSWORD
               value: uptrace
+          {{- if .Values.postgresql.persistence.enabled }}
+          volumeMounts:
+          - name: uptrace-postgresql-data
+            mountPath: /var/lib/postgresql
+          {{- else }}
           volumeMounts: []
+          {{- end }}
           ports:
             - name: tcp
               containerPort: 5432
@@ -88,4 +94,17 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes: []
+{{ if .Values.clickhouse.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: uptrace-postgresql-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      {{- if not (eq .Values.postgresql.persistence.storageClassName "") }}
+      storageClassName: {{ .Values.postgresql.persistence.storageClassName }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.postgresql.persistence.size }}
+{{ end }}
 {{ end }}

--- a/charts/uptrace/values.yaml
+++ b/charts/uptrace/values.yaml
@@ -28,6 +28,10 @@ postgresql:
     repository: postgres
     pullPolicy: IfNotPresent
     tag: '15-alpine'
+  persistence:
+    enabled: true
+    storageClassName: ''
+    size: 4Gi
 
 otelcol:
   enabled: true


### PR DESCRIPTION
Currently if the Postgres pod goes down, all existing alerts, dashboards, etc are deleted. 

Ideally if the pod was to go down (as they are ephemeral and it happens), I as a user would like to retain my dashboards at the very least.
The PR I'm requesting adds in the optional persistence similar to how it is set up for Clickhouse.