### PR TITLE
feat: add persistence options for postgresql statefulset

### DIFF
--- a/charts/uptrace/templates/postgresql-statefulset.yaml
+++ b/charts/uptrace/templates/postgresql-statefulset.yaml
@@ -43,7 +43,13 @@ spec:
               value: uptrace
             - name: POSTGRES_PASSWORD
               value: uptrace
+          {{- if .Values.postgresql.persistence.enabled }}
+          volumeMounts:
+          - name: uptrace-postgresql-data
+            mountPath: /var/lib/postgresql/data
+          {{- else }}
           volumeMounts: []
+          {{- end }}
           ports:
             - name: tcp
               containerPort: 5432
@@ -88,4 +94,17 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes: []
+{{ if .Values.postgresql.persistence.enabled }}
+  volumeClaimTemplates:
+  - metadata:
+      name: uptrace-postgresql-data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      {{- if not (eq .Values.postgresql.persistence.storageClassName "") }}
+      storageClassName: {{ .Values.postgresql.persistence.storageClassName }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.postgresql.persistence.size }}
+{{ end }}
 {{ end }}

--- a/charts/uptrace/values.yaml
+++ b/charts/uptrace/values.yaml
@@ -28,6 +28,10 @@ postgresql:
     repository: postgres
     pullPolicy: IfNotPresent
     tag: '15-alpine'
+  persistence:
+    enabled: true
+    storageClassName: '' # leave empty to use the default storage class
+    size: 8Gi
 
 otelcol:
   enabled: tre


### PR DESCRIPTION
This PR persists postgresql storage the same way it is for clickhouse:
```yaml
postgresql:
  enabled: true
  imagePullSecrets: []
  image:
    repository: postgres
    pullPolicy: IfNotPresent
    tag: '15-alpine'
  persistence:
    enabled: true
    storageClassName: '' # leave empty to use the default storage class
    size: 8Gi
```