### PR TITLE
Adding subPath to mount volume to avoid database start up issues

### DIFF
--- a/charts/uptrace/templates/postgresql-statefulset.yaml
+++ b/charts/uptrace/templates/postgresql-statefulset.yaml
@@ -46,7 +46,8 @@ spec:
           {{- if .Values.postgresql.persistence.enabled }}
           volumeMounts:
           - name: uptrace-postgresql-data
-            mountPath: /var/lib/postgresql/data
+            mountPath: /var/lib/postgresql
+            subPath: data
           {{- else }}
           volumeMounts: []
           {{- end }}


### PR DESCRIPTION
Without the subPath key, Postgres will complain that the data directory (which is the same as the mount point) is not empty. This is due to a lost+found directory being found.

Adding the subPath key fixes this issue.