### PR TITLE
Fixed typo in service.yaml template

### DIFF
--- a/charts/uptrace/templates/service.yaml
+++ b/charts/uptrace/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "uptrace.labels" . | nindent 4 }}
    {{- if .Values.uptrace.service.annotations }}
   annotations:
-  {{- with .Values.utprace.service.annotations }}
+  {{- with .Values.uptrace.service.annotations }}
   {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
This fixes the service annotations in the template