### PR TITLE
fix:(Otelcol.config): uses the Values instead of hard-coded

### DIFF
--- a/charts/uptrace/templates/otelcol-config.yaml
+++ b/charts/uptrace/templates/otelcol-config.yaml
@@ -31,9 +31,8 @@ data:
     exporters:
       debug:
       otlp/local:
-        endpoint: http://my-uptrace:14317
-        tls: { insecure: true }
-        headers: { 'uptrace-dsn': 'http://project1_secret_token@localhost:14317/1' }
+        otlp/local:
+        {{- .Values.otelcol.otlpExporter | toYaml | nindent 8 }}
     service:
       pipelines:
         traces:


### PR DESCRIPTION
## What this PR about:
The current charts/uptrace/templates/telco-config.yaml has a hard-coded exporter configuration, so if the chart name is changed, it will not work as expected. Now it uses the Values so that it can be configurable and the Chart will be useable out of the box 

## Fix
- Fix #48 