### PR TITLE
fix(postgresql): avoid cloudnative-pg operator lock

### DIFF
--- a/charts/uptrace/templates/uptrace-statefulset.yaml
+++ b/charts/uptrace/templates/uptrace-statefulset.yaml
@@ -58,6 +58,7 @@ spec:
               port: http
           {{ end }}
           env:
+          {{- if .Values.postgresql.enabled }}
             - name: PG_HOST
               valueFrom:
                 secretKeyRef:
@@ -78,6 +79,7 @@ spec:
                 secretKeyRef:
                   name: uptrace-postgresql-app
                   key: dbname
+            {{- end }}
             {{- toYaml .Values.uptrace.env | nindent 12 }}
           envFrom:
             {{- toYaml .Values.uptrace.envFrom | nindent 12 }}


### PR DESCRIPTION
Hello!

With next config

```yaml
postgresql:
  enabled: false

uptrace:
  config:
    pg:
      addr: 'uptrace-postgresql:5432'
      user: uptrace
      password: uptrace
      database: uptrace
```

there is still hardcoded `uptrace-postgresql-app` secret requirement.

This change will now make `uptrace-postgresql-app` secret used only when `postgresql.enabled: true` (that secret will be created by [CloudNativePG](https://cloudnative-pg.io/) PostgreSQL operator).

