### PR TITLE
feat: allow to template uptrace urls

### DIFF
--- a/charts/uptrace/templates/uptrace-configmap.yaml
+++ b/charts/uptrace/templates/uptrace-configmap.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "uptrace.labels" . | nindent 4 }}
 data:
   uptrace.yml: |
-{{ .Values.uptrace.config | toYaml | indent 4 }}
+{{ tpl (toYaml .Values.uptrace.config) $ | indent 4 }}

--- a/charts/uptrace/templates/uptrace-ingress.yaml
+++ b/charts/uptrace/templates/uptrace-ingress.yaml
@@ -23,7 +23,7 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    - host: {{ tpl .host $ }}
       http:
         paths:
           {{- range .paths }}

--- a/charts/uptrace/templates/uptrace-statefulset.yaml
+++ b/charts/uptrace/templates/uptrace-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
             - name: grpc
               containerPort: {{ .Values.uptrace.service.grpc_port }}
               protocol: TCP
-          {{ with .Values.uptrace.config.site.url | urlParse }}
+          {{ with (tpl .Values.uptrace.config.site.url $) | urlParse }}
           livenessProbe:
             httpGet:
               path: {{ .path }}

--- a/charts/uptrace/values.yaml
+++ b/charts/uptrace/values.yaml
@@ -206,6 +206,13 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
+    #
+    # For example, to inject the `url` value from the `site` section, use:
+    #
+    # - host: '{{ .Values.uptrace.site.url }}'
+    #   paths:
+    #     - path: /
+    #       pathType: Prefix
     - host: uptrace.local
       paths:
         - path: /
@@ -282,6 +289,11 @@ uptrace:
     ##
     ##   foo: $$FOO_BAR
     ##
+    ## Can be used with the `tpl` function to inject values from the values.yaml file.
+    ## For example, to inject the `url` value from the `site` section, use:
+    ##
+    ##   site:
+    ##     url: '{{ .Values.uptrace.site.url }}'
 
     ##
     ## Service configuration options.


### PR DESCRIPTION
The primary goal of this change is to enable the URL to be dynamic, thereby avoiding the need to hardcode it in multiple places.

eg

```yaml
uptrace:
  hostname: uptrace.foo.com
  config:
    site:
      url: 'https://{{ .Values.hostname }}/'
  ingress:
    hosts:
      - host: '{{ .Values.hostname }}'
```