### PR TITLE
fix(postgresql): correct imageName typo in postgresql-cluster.yml

### DIFF
--- a/charts/uptrace/templates/postgresql-cluster.yml
+++ b/charts/uptrace/templates/postgresql-cluster.yml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
 
 spec:
-  imageName: {{ .Values.postgresql.imageNname }}
+  imageName: {{ .Values.postgresql.imageName }}
   imagePullSecrets:
     {{- toYaml .Values.postgresql.imagePullSecrets | nindent 4 }}
 


### PR DESCRIPTION
literally fix the typo